### PR TITLE
Support Python 3.8

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,8 +18,8 @@ Unit testing is performed with every pull request or commit to `main`.
 
 | Version |                    Supported                    |
 |:--------|:-----------------------------------------------:|
-| \>= 3.9 | ![Yes](https://img.shields.io/badge/-YES-green) |
-| <= 3.8  |   ![No](https://img.shields.io/badge/-NO-red)   |
+| \>= 3.8 | ![Yes](https://img.shields.io/badge/-YES-green) |
+| <= 3.7  |   ![No](https://img.shields.io/badge/-NO-red)   |
 
 ## Supported CrowdStrike regions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [project]
 name = "crowdstrike-foundry-function"
 description = "CrowdStrike Foundry Function Software Developer Kit for Python"
-requires-python = ">=3.9.0"
+requires-python = ">=3.8.0"
 dynamic = ['dependencies', 'version']
+readme = "README.md"
 
 [build-system]
 requires = ['setuptools>=67.7.2']

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ PACKAGE_DIR = {
 PACKAGES = [
     'crowdstrike.foundry.function',
 ]
-PYTHON_VERSION = '>=3.9.0'
+PYTHON_VERSION = '>=3.8.0'
 SETUP_REQUIRES = [
     'setuptools',
 ]
-VERSION = '0.5.3'
+VERSION = '0.6.0'
 
 
 def main():


### PR DESCRIPTION
Adds support for Python 3.8.

To support certain build processes, we are expanding support of this framework to Python 3.8.  Python 3.8 is deprecated in many places, but is not yet fully sunset in some Linux distributions.