### PR TITLE
Support for files as input to function handlers

### DIFF
--- a/examples/complex_inputs/complex_inputs_example.py
+++ b/examples/complex_inputs/complex_inputs_example.py
@@ -1,0 +1,29 @@
+from crowdstrike.foundry.function import Function, Request, Response, APIError
+from logging import Logger
+
+func = Function.instance()
+
+
+@func.handler(method='POST', path='/my-endpoint')
+def handle_complex_inputs(request: Request, config: [dict[str, any], None], logger: Logger) -> Response:
+    '''
+    handle_complex_inputs showcases how to provide multiple inputs to a function, some of which happen to be files.
+    In this case, it simply echoes back the contents of those files concatenated together with spaces.
+    This could easily be changed to something more advanced to work with arbitrary binary.
+    '''
+    greeting = f'Welcome {request.body.get("name", "<unknown>")}, age {request.body.get("age", "<unknown>")}'
+    file_contents = []
+    for v in request.files.values():
+        file_contents.append(v.decode('utf-8').strip())
+
+    return Response(
+        body={
+            'allText': ' '.join(file_contents),
+            'greeting': greeting,
+        },
+        code=200,
+    )
+
+
+if __name__ == '__main__':
+    func.run()

--- a/examples/complex_inputs/lorem-ipsum-1.txt
+++ b/examples/complex_inputs/lorem-ipsum-1.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/examples/complex_inputs/lorem-ipsum-2.txt
+++ b/examples/complex_inputs/lorem-ipsum-2.txt
@@ -1,0 +1,1 @@
+Nam facilisis condimentum tellus, quis pharetra erat dignissim vel.

--- a/examples/complex_inputs/lorem-ipsum-3.txt
+++ b/examples/complex_inputs/lorem-ipsum-3.txt
@@ -1,0 +1,1 @@
+Donec ullamcorper diam nec commodo laoreet.

--- a/examples/complex_inputs/test.sh
+++ b/examples/complex_inputs/test.sh
@@ -1,0 +1,13 @@
+curl -X POST --location "http://localhost:8081" \
+    -H "Content-Type: multipart/form-data" \
+    -F meta='{
+          "url": "/my-endpoint",
+          "method": "POST"
+      }' \
+    -F body='{
+           "name": "Sam",
+           "age": 35
+       }' \
+    -F file1='@lorem-ipsum-1.txt;filename=lorem-ipsum-1.txt' \
+    -F file2='@lorem-ipsum-2.txt;filename=lorem-ipsum-2.txt' \
+    -F file3='@lorem-ipsum-3.txt;filename=lorem-ipsum-3.txt'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 build>=1.0.3
 pytest>=7.4.2
+python-multipart>=0.0.20
 urllib3>=1.26.16,<2.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ PYTHON_VERSION = '>=3.8.0'
 SETUP_REQUIRES = [
     'setuptools',
 ]
-VERSION = '1.0.1'
+VERSION = '1.1.0'
 
 
 def main():

--- a/src/crowdstrike/foundry/function/model.py
+++ b/src/crowdstrike/foundry/function/model.py
@@ -19,6 +19,7 @@ class Request:
     access_token: str = field(default='')
     body: Dict[str, any] = field(default_factory=lambda: {})
     context: Dict[str, any] = field(default_factory=lambda: {})
+    files: Dict[str, bytes] = field(default_factory=lambda: {})
     fn_id: str = field(default='')
     fn_version: int = field(default=0)
     method: str = field(default='')


### PR DESCRIPTION
Addresses the need to allow functions to accept files and mixed type inputs as inbound requests. This change allows for the following:

- Allows for requests of a single file to be accepted by a function.
- Allows for requests of multiple inbound files to be accepted by a function.
- Allows for requests of mixed input types (file(s) and JSON) to be accepted as input by a function.

Example is included showcasing how to use the input types.